### PR TITLE
Align jekyll-feed plugin version with gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 group :jekyll_plugins do
-    gem "jekyll-feed", "~> 0.6"
+    gem "jekyll-feed", "~> 0.15"
     gem "jekyll-sitemap"
     gem "jekyll-paginate"
     gem "jekyll-seo-tag"


### PR DESCRIPTION
## Summary
- update the Gemfile to require jekyll-feed ~> 0.15 so it matches the gemspec

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden" when fetching rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d1d3e7a88324950e835d9605f4ec